### PR TITLE
 Add EEPROM Emulation Layer for SAMD CPU (Feather M0 etc.) 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
     fi
   - arduino --pref "boardsmanager.additional.urls=" --save-prefs
 install:
-  - arduino --install-library "U8g2"
+  - arduino --install-library "U8g2","FlashStorage"
 script:
   - cp -f $PWD/crossbow/configurations/config_${CONFIG}.h $PWD/crossbow/config.h &&
     arduino --verify --board $BOARD $PWD/crossbow/crossbow.ino

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Needs implementation:
 To compile, following libraries have to be installed:
 
 * [U8g2](https://github.com/olikraus/u8g2) for OLED support in TX module
+* [FlashStorage](https://github.com/cmaglie/FlashStorage) for EEPROM-Emulation if using a SAMD-Board (M0 etc.)
 
 # Protocol
 

--- a/crossbow/platform_node.cpp
+++ b/crossbow/platform_node.cpp
@@ -20,6 +20,9 @@ void PlatformNode::seed(void) {
         EEPROM.write(EEPROM_ADDRESS_BIND_2, random(1, 255)); //Yes, from 1 to 254
         EEPROM.write(EEPROM_ADDRESS_BIND_3, random(1, 255)); //Yes, from 1 to 254
         EEPROM.write(EEPROM_ADDRESS_BIND_KEY_SEEDED, 0xf1);
+        #ifdef ARDUINO_SAMD_FEATHER_M0
+        EEPROM.commit();
+        #endif
     } 
 }
 
@@ -36,6 +39,9 @@ void PlatformNode::saveBindKey(uint8_t key[]) {
     EEPROM.write(EEPROM_ADDRESS_BIND_2, key[2]);
     EEPROM.write(EEPROM_ADDRESS_BIND_3, key[3]);
     EEPROM.write(EEPROM_ADDRESS_BIND_KEY_SEEDED, 0xf1);
+    #ifdef ARDUINO_SAMD_FEATHER_M0
+    EEPROM.commit();
+    #endif
 }
 
 int PlatformNode::getRcChannel(uint8_t channel) {

--- a/crossbow/platform_node.h
+++ b/crossbow/platform_node.h
@@ -2,7 +2,12 @@
 
 #include "Arduino.h"
 #include "radio_node.h"
+#ifdef ARDUINO_AVR_FEATHER32U4
 #include <EEPROM.h>
+#elif defined(ARDUINO_SAMD_FEATHER_M0)
+// Include EEPROM-like API for FlashStorage
+#include <FlashAsEEPROM.h>
+#endif
 
 #ifndef PLATFORM_NODE_H
 #define PLATFORM_NODE_H


### PR DESCRIPTION
The M0 does not have an EEPROM, instead we are using an emulation layer, provided by the Library cmaglie/FlashStorage